### PR TITLE
Chore: Pin ruff rule selection

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+# Pin the ruff rule set explicitly.
+#
+# Without a `select`, ruff applies its *default* rule set, and that
+# default is not stable across releases:
+#
+#     ruff 0.15.22 ->  59 rules across  2 categories (E, F)
+#     ruff 0.16.0  -> 413 rules across 38 categories
+#
+# A routine pre-commit autoupdate crossing that boundary changed which
+# rules run and broke fifteen repositories in this organisation at once,
+# on code nobody had touched.
+#
+# Selecting these categories switches every other rule off.  That is the
+# point: adopting more becomes a deliberate, reviewed edit to this file
+# rather than a side effect of a version bump.
+#
+# `line-length` and `target-version` are intentionally left unset so
+# ruff's own defaults continue to apply unchanged.
+
+[lint]
+# The de facto standard across this organisation: present as a superset
+# in 13 of the 16 repositories that already pin their rules.
+select = ["E", "W", "F", "I", "B", "C4", "UP"]
+
+ignore = [
+  "E501", # line-too-long: the formatter owns line length
+  "B008", # function call in argument default: typer/click idiom
+]
+
+[lint.per-file-ignores]
+# Test suites legitimately break rules that matter in library code.
+# Listed even where not currently selected, so that widening `select`
+# later does not immediately flag every test module.  PLR0917 in
+# particular cannot be satisfied by tests that stack `@patch`
+# decorators: unittest.mock injects its mocks positionally, so a
+# keyword-only signature is impossible, not merely inconvenient.
+"tests/**/*.py" = ["S101", "ARG", "PLR0913", "PLR0917", "PLR2004"]


### PR DESCRIPTION
## Why

This repo runs the ruff hook with **no ruff configuration**, so it applies whatever ruff's *default* rule set happens to be. That default is not stable across releases — verified directly:

```
$ ruff 0.15.22 check --show-settings --isolated
 59 rules across  2 categories (E, F)

$ ruff 0.16.0 check --show-settings --isolated
413 rules across 38 categories
```

A 7× expansion in a patch-level bump. The routine autoupdate that crossed it **broke 15 repos in this org simultaneously** on untouched code — including this one, where #102 is blocked.

## What

```toml
[lint]
select = ["E", "W", "F", "I", "B", "C4", "UP"]
ignore = ["E501", "B008"]
```

Not invented — this is the **de facto house style**, a superset in 13 of the 16 org repos that already pin their rules.

A standalone `.ruff.toml` because this repo has no `pyproject.toml`.

**Selecting these categories switches every other rule off — that is the point.** Adopting them becomes a deliberate, reviewed change rather than a side effect of a version bump.

`line-length` and `target-version` are left unset on purpose — both would change behaviour rather than pin it (`target-version` alters which `pyupgrade` rules fire). Standardising those is separate work.

## Effect on #102

The single blocking violation falls outside the pinned set and ceases to exist: `EXE001` on `tests/test-projects.py:1` (shebang present, file not executable). `EXE` is not selected.

Worth noting the alternative was to delete a shebang from a file that is mode `644` and never invoked directly — a change with no benefit beyond satisfying a rule the org had not chosen to adopt.

## Validation

- No code changes needed — verified clean under the pinned set with ruff 0.16.0 against the files the hook selects
- `ruff check --show-settings` confirms enabled categories drop from 38 to `B C E F I UP W`
- `pre-commit run --all-files` → all hooks pass
