### PR TITLE
Fix: Env-mediate expressions in run blocks

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -113,16 +113,22 @@ jobs:
 
       - name: "Debug: Check SBOM generation outputs"
         shell: bash
+        env:
+          SBOM_OUTCOME: ${{ steps.generate-sbom.outcome }}
+          SBOM_MANAGER: ${{ steps.generate-sbom.outputs.dependency_manager }}
+          SBOM_COUNT: ${{ steps.generate-sbom.outputs.component_count }}
+          SBOM_JSON_PATH: ${{ steps.generate-sbom.outputs.sbom_json_path }}
+          SBOM_XML_PATH: ${{ steps.generate-sbom.outputs.sbom_xml_path }}
         run: |
           echo "🔍 Checking SBOM generation results:"
-          echo "Step outcome: ${{ steps.generate-sbom.outcome }}"
-          detected_mgr="${{ steps.generate-sbom.outputs.dependency_manager }}"
+          echo "Step outcome: $SBOM_OUTCOME"
+          detected_mgr="$SBOM_MANAGER"
           echo "Dependency manager: '$detected_mgr'"
-          component_count="${{ steps.generate-sbom.outputs.component_count }}"
+          component_count="$SBOM_COUNT"
           echo "Component count: '$component_count'"
-          json_path="${{ steps.generate-sbom.outputs.sbom_json_path }}"
+          json_path="$SBOM_JSON_PATH"
           echo "JSON path: '$json_path'"
-          xml_path="${{ steps.generate-sbom.outputs.sbom_xml_path }}"
+          xml_path="$SBOM_XML_PATH"
           echo "XML path: '$xml_path'"
           echo ""
           echo "🔍 Looking for generated files:"
@@ -135,11 +141,16 @@ jobs:
           MATRIX_DESCRIPTION: ${{ matrix.description }}
           MATRIX_REPOSITORY: ${{ matrix.repository }}
           EXPECTED_MANAGER: ${{ matrix.expected_manager }}
+          SBOM_OUTCOME: ${{ steps.generate-sbom.outcome }}
+          SBOM_MANAGER: ${{ steps.generate-sbom.outputs.dependency_manager }}
+          SBOM_COUNT: ${{ steps.generate-sbom.outputs.component_count }}
+          SBOM_JSON_PATH: ${{ steps.generate-sbom.outputs.sbom_json_path }}
+          SBOM_XML_PATH: ${{ steps.generate-sbom.outputs.sbom_xml_path }}
         run: |
           echo "🔍 Validating SBOM generation for $MATRIX_DESCRIPTION"
 
           # Check if SBOM generation succeeded
-          if [[ "${{ steps.generate-sbom.outcome }}" != "success" ]]; then
+          if [[ "$SBOM_OUTCOME" != "success" ]]; then
             desc="$MATRIX_DESCRIPTION"
             echo "❌ SBOM generation failed for $desc"
             echo "This might be expected for some repos"
@@ -151,7 +162,7 @@ jobs:
           echo "✅ SBOM generation succeeded"
 
           # Validate dependency manager detection
-          detected="${{ steps.generate-sbom.outputs.dependency_manager }}"
+          detected="$SBOM_MANAGER"
           expected="$EXPECTED_MANAGER"
 
           if [[ -n "$detected" && "$detected" != "$expected" ]]; then
@@ -167,8 +178,8 @@ jobs:
           xml_found=false
 
           # Get the actual file paths from action outputs
-          json_path="${{ steps.generate-sbom.outputs.sbom_json_path }}"
-          xml_path="${{ steps.generate-sbom.outputs.sbom_xml_path }}"
+          json_path="$SBOM_JSON_PATH"
+          xml_path="$SBOM_XML_PATH"
 
           if [[ -n "$json_path" && -f "$json_path" ]]; then
             json_found=true
@@ -187,7 +198,7 @@ jobs:
           fi
 
           # Check component count if available
-          component_count="${{ steps.generate-sbom.outputs.component_count }}"
+          component_count="$SBOM_COUNT"
           if [[ -n "$component_count" && "$component_count" != "0" ]]; then
             echo "✅ Component count: $component_count"
           elif [[ "$component_count" == "0" ]]; then


### PR DESCRIPTION
## Why

The org-wide zizmor workflow (`lfreleng-actions/.github/workflows/zizmor.yaml`) was changed today:

```
2026-07-28T10:46  Feat: Surface all zizmor findings at any level
```

It runs `--persona auditor --min-severity informational` and now **fails a run on any finding at any level**. This repo carries 10 pre-existing `template-injection` findings — the most of any repo I've looked at — so *every* new PR here is blocked until they're cleared, currently #103.

## What

`.github/workflows/testing.yaml` expanded `generate-sbom` outputs directly inside `run:` blocks. GitHub expands `${{ }}` *before* the shell sees the script, so a crafted value becomes shell source text rather than data. Routing through `env:` makes the value opaque to the shell parser.

Two steps were affected — the debug dump and the validation step. The validation step already declared an `env:` block for its matrix values, so the SBOM outputs simply join it:

```yaml
env:
  MATRIX_DESCRIPTION: ${{ matrix.description }}
  MATRIX_REPOSITORY: ${{ matrix.repository }}
  EXPECTED_MANAGER: ${{ matrix.expected_manager }}
  SBOM_OUTCOME: ${{ steps.generate-sbom.outcome }}
  SBOM_MANAGER: ${{ steps.generate-sbom.outputs.dependency_manager }}
  ...
```

Same shape `python-workflows` uses (see its "Fix: Env-mediate expressions in run blocks"), and the `env:`-before-`run:` ordering already used elsewhere here.

**On naming:** `python-workflows` used `SBOM_COMPONENT_COUNT` / `SBOM_DEPENDENCY_MANAGER`. Here the step id is `generate-sbom` rather than `sbom`, which pushes those lines past the 80-column limit `yamllint` enforces in this repo. I shortened to `SBOM_COUNT` / `SBOM_MANAGER` rather than scatter `# yamllint disable-line` suppressions.

## ⚠️ Why this was written by hand

zizmor offers an auto-fix for this audit. It is marked *unsafe*, and on inspection it is: it rewrites expressions in place while leaving them inside their original quoting, and the shell does not expand `${...}` inside single quotes. The original code was correct precisely *because* GitHub expanded the template before the shell ran; once the value moves to `env:`, expansion becomes the shell's job and the quoting has to change with it.

This repo's call sites happened to use double quotes so the auto-fix would have survived here — but it silently breaks sibling repos, so all of these were done by hand and re-verified.

The auto-fix also emitted a duplicated `env:` block on one step, which is a second reason not to take its output verbatim.

## Validation

- `zizmor --persona auditor --min-severity informational` → **No findings to report**
- `pre-commit run --all-files` → all hooks pass, including `yamllint` and `actionlint`
- No behavioural change: the same values reach the same commands

Unblocks #103.
